### PR TITLE
Update template

### DIFF
--- a/template/template
+++ b/template/template
@@ -6946,6 +6946,13 @@ body.skin-3 {
 	color: #fff;
 	background-color: #1ab394
 }
+#detailBody{
+    width: 100%;
+    height: auto;
+    word-wrap:break-word;
+    word-break:break-all;
+    overflow: hidden;
+}
 
 @media (min-width:768px) {
 	.bs-glyphicons {


### PR DESCRIPTION
解决因报告Log文本过长，无法点击‘收缩‘按钮。